### PR TITLE
Cron job

### DIFF
--- a/iac/cron-job.tf
+++ b/iac/cron-job.tf
@@ -1,0 +1,119 @@
+resource "kubernetes_namespace" "cron_ns" {
+  metadata {
+    name = "cron-jobs"
+  }
+}
+
+
+resource "kubernetes_secret" "cronjob_cleanup_secrets" {
+  metadata {
+    name      = "lab-cleanup-secret"
+    namespace = kubernetes_namespace.cron_ns.metadata[0].name
+  }
+  data = {
+    AUTH0_DOMAIN        = var.auth0_domain
+    AUTH0_CLIENT_ID     = var.auth0_lab_automation_client_id
+    AUTH0_CLIENT_SECRET = var.auth0_lab_automation_client_secret
+    AUTH0_AUDIENCE      = var.auth0_audience
+    BACKEND_URL         = var.backend_url
+
+
+  }
+  type = "Opaque"
+}
+
+
+resource "kubernetes_cron_job_v1" "lab_cleanup" {
+  metadata {
+    name      = "backend-lab-cleanup"
+    namespace = kubernetes_namespace.cron_ns.metadata[0].name
+    labels = {
+      app = "lab-cleanup-trigger"
+    }
+  }
+
+  spec {
+    schedule                      = "*/10 * * * *"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 1
+
+    job_template {
+      metadata {
+        labels = {
+          app = "lab-cleanup-trigger"
+        }
+      }
+
+      spec {
+        template {
+          metadata {
+            labels = {
+              app = "lab-cleanup-trigger"
+            }
+          }
+
+          spec {
+            restart_policy = "OnFailure"
+
+            container {
+              name              = "lab-cleanup-trigger"
+              image             = "ghcr.io/cloudsteak/lab-cleanup-trigger:latest"
+              image_pull_policy = "Always"
+
+              env {
+                name = "AUTH0_DOMAIN"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret.cronjob_cleanup_secrets.metadata[0].name
+                    key  = "AUTH0_DOMAIN"
+                  }
+                }
+              }
+
+              env {
+                name = "AUTH0_CLIENT_ID"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret.cronjob_cleanup_secrets.metadata[0].name
+                    key  = "AUTH0_CLIENT_ID"
+                  }
+                }
+              }
+
+              env {
+                name = "AUTH0_CLIENT_SECRET"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret.cronjob_cleanup_secrets.metadata[0].name
+                    key  = "AUTH0_CLIENT_SECRET"
+                  }
+                }
+              }
+
+              env {
+                name = "AUTH0_AUDIENCE"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret.cronjob_cleanup_secrets.metadata[0].name
+                    key  = "AUTH0_AUDIENCE"
+                  }
+                }
+              }
+
+              env {
+                name = "BACKEND_URL"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret.cronjob_cleanup_secrets.metadata[0].name
+                    key  = "BACKEND_URL"
+                  }
+                }
+              }
+
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -33,7 +33,7 @@ resource "kubernetes_secret" "lab_secrets" {
 
 resource "kubernetes_secret" "ghcr_auth" {
   metadata {
-    name = "ghcr-auth"
+    name      = "ghcr-auth"
     namespace = kubernetes_namespace.lab_ns.metadata[0].name
   }
   type = "kubernetes.io/dockerconfigjson"
@@ -41,7 +41,7 @@ resource "kubernetes_secret" "ghcr_auth" {
     ".dockerconfigjson" = jsonencode({
       "auths" = {
         "https://ghcr.io" = {
-          "auth" :  base64encode("the1bit:${var.github_token}")
+          "auth" : base64encode("the1bit:${var.github_token}")
         }
       }
     })
@@ -55,7 +55,9 @@ resource "kubernetes_config_map" "lab_config" {
     namespace = kubernetes_namespace.lab_ns.metadata[0].name
   }
   data = {
-    LAB_TTL_SECONDS = var.lab_ttl_seconds
+    LAB_TTL_SECONDS  = var.lab_ttl_seconds
+    PORTAL_AZURE_URL = var.azure_portal_url
+    PORTAL_AWS_URL   = var.aws_portal_url
   }
 }
 

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -26,6 +26,19 @@ variable "auth0_domain" {
   sensitive = true
 }
 
+variable "auth0_lab_automation_client_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "auth0_lab_automation_client_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "auth0_audience" {
+  type = string
+}
 variable "github_token" {
   type      = string
   sensitive = true
@@ -35,9 +48,7 @@ variable "email_sender" {
   type = string
 }
 
-variable "auth0_audience" {
-  type = string
-}
+
 
 variable "auth0_algorithms" {
   type    = string
@@ -59,5 +70,17 @@ variable "lab_ttl_seconds" {
 
 
 variable "redis_host" {
+  type = string
+}
+
+variable "azure_portal_url" {
+  type = string
+}
+
+variable "aws_portal_url" {
+  type = string
+}
+
+variable "backend_url" {
   type = string
 }


### PR DESCRIPTION
This pull request includes significant updates to the infrastructure as code (IaC) configuration, primarily focusing on setting up a new Kubernetes cron job for lab cleanup and adding new configuration variables.

### Kubernetes Cron Job Setup:

* Added a new namespace `cron_ns` for cron jobs in `iac/cron-job.tf`.
* Created a Kubernetes secret `cronjob_cleanup_secrets` to store sensitive data required by the cron job.
* Defined a Kubernetes cron job `lab_cleanup` to run the lab cleanup task every 10 minutes, using the `lab-cleanup-trigger` container image.

### Configuration Updates:

* Added new variables `auth0_lab_automation_client_id`, `auth0_lab_automation_client_secret`, `azure_portal_url`, `aws_portal_url`, and `backend_url` in `iac/variables.tf` to support the new cron job and other configurations. [[1]](diffhunk://#diff-e8d371653bf2fbe8f9cbfbac9d73752d08ed7f41830b45e280ec4017d90bed49L29-R51) [[2]](diffhunk://#diff-e8d371653bf2fbe8f9cbfbac9d73752d08ed7f41830b45e280ec4017d90bed49R75-R86)
* Updated the `kubernetes_config_map` resource in `iac/main.tf` to include `PORTAL_AZURE_URL` and `PORTAL_AWS_URL`.