### PR TITLE
Rename Docker image references

### DIFF
--- a/.github/workflows/docker-build-lab-backend.yml
+++ b/.github/workflows/docker-build-lab-backend.yml
@@ -44,5 +44,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/cloudsteak/student-lab-backend:latest
-            ghcr.io/cloudsteak/student-lab-backend:${{ steps.vars.outputs.SHORT_SHA }}
+            ghcr.io/cloudsteak/lab-backend:latest
+            ghcr.io/cloudsteak/lab-backend:${{ steps.vars.outputs.SHORT_SHA }}


### PR DESCRIPTION
Update the Docker image references to use the new naming convention for the lab backend.