### PR TITLE
Rename and modify Docker images for lab cleanup and backend

### DIFF
--- a/.github/workflows/docker-build-lab-cleanup.yml
+++ b/.github/workflows/docker-build-lab-cleanup.yml
@@ -42,5 +42,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/cloudsteak/student-lab-cleanup-trigger:latest
-            ghcr.io/cloudsteak/student-lab-cleanup-trigger:${{ steps.vars.outputs.SHORT_SHA }}
+            ghcr.io/cloudsteak/lab-cleanup-trigger:latest
+            ghcr.io/cloudsteak/lab-cleanup-trigger:${{ steps.vars.outputs.SHORT_SHA }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lásd `.env.example` fájlt.
 
 ## Docker képfájl fordítása helyben:
 ```bash
-docker buildx build --platform linux/amd64 -t ghcr.io/cloudsteak/student-lab-backend:latest .
+docker buildx build --platform linux/amd64 -t ghcr.io/cloudsteak/lab-backend:latest .
 ```
 
 

--- a/iac/cron-job.tf
+++ b/iac/cron-job.tf
@@ -57,7 +57,7 @@ resource "kubernetes_cron_job_v1" "lab_cleanup" {
 
             container {
               name              = "lab-cleanup-trigger"
-              image             = "ghcr.io/cloudsteak/student-lab-cleanup-trigger:latest"
+              image             = "ghcr.io/cloudsteak/lab-cleanup-trigger:latest"
               image_pull_policy = "Always"
 
               env {

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -88,7 +88,7 @@ resource "kubernetes_deployment" "lab_backend" {
         }
         container {
           name  = "backend"
-          image = var.image
+          image = "ghcr.io/cloudsteak/lab-backend:latest"
           port {
             container_port = 8000
           }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -11,10 +11,6 @@ variable "kubeconfig_context" {
 }
 
 
-variable "image" {
-  description = "Docker image"
-  type        = string
-}
 
 variable "brevo_api_key" {
   type      = string


### PR DESCRIPTION
Update Docker image names for the lab cleanup trigger and backend services to reflect a new naming convention. Remove the unused image variable from the configuration.